### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,30 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9.0-rc.1]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --profile black --recursive . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -23,8 +23,8 @@ jobs:
       #  run: |
       #    pip install black
       #    black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --ignore-words-list="nwo" --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --profile black --recursive . || true
+      - run: isort --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: pytest . || true

--- a/docs/examples/dataset-loop.md
+++ b/docs/examples/dataset-loop.md
@@ -46,7 +46,7 @@ for i in dataset.index:
 dataset.loc[:, 'alk'] *= 1e6 # convert to micromol/kg
 ```
 
-Note that the CRMs have been calibrated using the average acid concentration, not using their own indiviual calibrations, so their alkalinities are not *exactly* the same as the certified values.
+Note that the CRMs have been calibrated using the average acid concentration, not using their own individual calibrations, so their alkalinities are not *exactly* the same as the certified values.
 
 Finally, we can export the results back into a file, if required:
 


### PR DESCRIPTION
Output: https://github.com/cclauss/calkulate/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.