### PR TITLE
Python version related updates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "Calkulate"
 description = "Calkulate: seawater total alkalinity from titration data"
 readme = "README.md"
+requires-python = ">=3.7"
 dependencies = [
     "PyCO2SYS",
     "matplotlib",
@@ -24,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Natural Language :: English",


### PR DESCRIPTION
Setting requires-python=3.7
Adding 3.7 to matrix
Flagging Python 3.13 support in metadata